### PR TITLE
[JENKINS-66314] Prepare ElasTest for core Guava upgrade

### DIFF
--- a/src/main/java/jenkins/plugins/elastest/submitters/LogstashSubmitter.java
+++ b/src/main/java/jenkins/plugins/elastest/submitters/LogstashSubmitter.java
@@ -23,7 +23,6 @@
 
 package jenkins.plugins.elastest.submitters;
 
-import static com.google.common.collect.Ranges.closedOpen;
 import static java.lang.invoke.MethodHandles.lookup;
 import static org.slf4j.LoggerFactory.getLogger;
 import org.slf4j.Logger;
@@ -47,8 +46,6 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 
-import com.google.common.collect.Range;
-
 /**
  * Logstash submitter.
  *
@@ -61,7 +58,6 @@ public class LogstashSubmitter extends AbstractElasTestSubmitter {
     final HttpClientBuilder clientBuilder;
     final URI uri;
     final String auth;
-    final Range<Integer> successCodes = closedOpen(200, 300);
 
     // primary constructor used by indexer factory
     public LogstashSubmitter(String host, int port, String key, String username,
@@ -124,8 +120,8 @@ public class LogstashSubmitter extends AbstractElasTestSubmitter {
             httpClient = clientBuilder.build();
             response = httpClient.execute(post);
 
-            if (!successCodes
-                    .contains(response.getStatusLine().getStatusCode())) {
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode < 200 || statusCode >= 300) {
                 throw new IOException(this.getErrorMessage(response));
             }
             sentMessage = true;

--- a/src/main/java/jenkins/plugins/elastest/utils/Shell.java
+++ b/src/main/java/jenkins/plugins/elastest/utils/Shell.java
@@ -28,10 +28,10 @@ import java.io.InputStreamReader;
 import java.io.Serializable;
 import java.util.Arrays;
 
+import org.apache.commons.io.IOUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.io.CharStreams;
 
 public class Shell implements Serializable {
     private static final long serialVersionUID = 1L;
@@ -80,7 +80,7 @@ public class Shell implements Serializable {
         try {
             p = new ProcessBuilder(command).redirectErrorStream(true).start();
 
-            String output = CharStreams.toString(
+            String output = IOUtils.toString(
                     new InputStreamReader(p.getInputStream(), "UTF-8"));
 
             p.destroy();


### PR DESCRIPTION
See [JENKINS-66314](https://issues.jenkins.io/browse/JENKINS-66314) and [JENKINS-65988](https://issues.jenkins.io/browse/JENKINS-65988). Jenkins core is using [Guava 11.0.1](https://github.com/google/guava/releases/tag/v11.0.1), which was released on January 9, 2012. Jenkins core would like to upgrade to [Guava 30.1.1](https://github.com/google/guava/releases/tag/v30.1.1), which was released on March 19, 2021. Plugins must be prepared to be compatible with both Guava 11.0.1 and Guava 30.1.1 in advance of this core transition.

In particular, this plugin has been identified as using the `com.google.common.collect.Ranges` class, which existed in Guava [11.0.1](https://guava.dev/releases/11.0.1/api/docs/com/google/common/collect/Ranges.html) but has been removed in later versions.

To facilitate the Jenkins core transition, this plugin must be prepared and released such that it works with both Guava 11.0.1 and latest. The general recommendation is to rewrite the code to avoid the use of the `Ranges` class. In this PR I am removing all usages of Guava from this plugin.

CC @EduJGURJC